### PR TITLE
fixes #12

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -70,9 +70,10 @@ class Zipper
 
         $name = 'Chumper\Zipper\Repositories\\' . ucwords($type) . 'Repository';
         if (is_subclass_of($name, 'Chumper\Zipper\Repositories\RepositoryInterface'))
-            $this->repository = $type;
-        else
             $this->repository = new $name($pathToFile, $new);
+        else
+	        //TODO $type should be a class name and not a string
+            $this->repository = $type;
 
         return $this;
     }


### PR DESCRIPTION
I am not sure whate the check in line 72 is for. But with this fix the default repository will be an instance of ZipRepository. The error was caused because $this->repository was set as a string instead of an object.
