### PR TITLE
fix bug in L5

### DIFF
--- a/src/Chumper/Zipper/ZipperServiceProvider.php
+++ b/src/Chumper/Zipper/ZipperServiceProvider.php
@@ -19,7 +19,7 @@ class ZipperServiceProvider extends ServiceProvider {
      */
     public function boot()
     {
-        $this->package('chumper/zipper');
+
     }
 
     /**


### PR DESCRIPTION
i guess `$this->package` is removed as of L5 it is not in documentation
http://laravel.com/docs/5.0/providers
