### PR TITLE
Fix for addition of folders on Windows

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -360,7 +360,7 @@ class Zipper
         // Now let's visit the subdirectories and add them, too.
         foreach ($this->file->directories($pathToDir) as $dir) {
             $old_folder = $this->currentFolder;
-            $this->currentFolder = $this->currentFolder . '/' . basename($dir);
+            $this->currentFolder = empty($this->currentFolder) ? basename($dir) : $this->currentFolder . '/' . basename($dir);
             $this->addDir($pathToDir . '/' . basename($dir));
             $this->currentFolder = $old_folder;
         }


### PR DESCRIPTION
As per issue #33, folders that begin with a '/' causes issues on Windows. This fix addresses this...