### PR TITLE
Remove realpath() from extractTo() method

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -113,7 +113,6 @@ class Zipper
      */
     public function extractTo($path, array $files = array(), $method = Zipper::BLACKLIST)
     {
-        $path = realpath($path);
         if (!$this->file->exists($path))
             $this->file->makeDirectory($path, 0755, true);
 


### PR DESCRIPTION
Remove realpath() from extractTo() method which prevents creating non-existing directory