### PR TITLE
extract logic refactored to support excact and regex matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,21 @@
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
+  - 5.6
+  - 7
+
+env:
+  - COMPOSER_FLAGS=--prefer-lowest
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - travis_retry composer self-update
+  - travis_retry composer update --no-interaction --prefer-source --prefer-stable ${COMPOSER_FLAGS}
+
+install:
+    - travis_retry composer update --no-interaction
 
 script: phpunit

--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ Lists all files within archive (if no filter pattern is provided). Use `$regexFi
 > NB: `listFiles` ignores folder set with `folder` function
 
 
-Example: Return all files/folders ending with '.log' pattern (case insensitive). This will return matches in sub folders and their sub folders also
+Example: Return all files/folders ending/not ending with '.log' pattern (case insensitive). This will return matches in sub folders and their sub folders also
+
 ```php
-$files = Zipper::make('test.zip')->listFiles('/\.log$/i'); 
+$logFiles = Zipper::make('test.zip')->listFiles('/\.log$/i'); 
+$notLogFiles = Zipper::make('test.zip')->listFiles('/^(?!.*\.log).*$/i'); 
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,20 @@ test.zip
     |- fileInSubFolder.log
 ```
 
+##extractMatchingRegex($path, $regex)
+
+Extracts the content of the zip archive matching regular expression to the specified location. See [Pattern Syntax](http://php.net/manual/en/reference.pcre.pattern.syntax.php) for regular expression syntax.
+
+Example: extract all files ending with `.php` from `src` folder and its sub folders.
+```php
+Zipper::make('test.zip')->folder->('src')->extractMatchingRegex($path, '/\.php$/i'); 
+```
+
+Example: extract all files **except** those ending with `test.php` from `src` folder and its sub folders.
+```php
+Zipper::make('test.zip')->folder->('src')->extractMatchingRegex($path, '/^(?!.*test\.php).*$/i'); 
+```
+
 #Development
 
 Maybe it is a good idea to add other compression functions like rar, phar or bzip2 etc...

--- a/README.md
+++ b/README.md
@@ -122,15 +122,31 @@ white listed
 >**Zipper::WHITELIST**
 >
 	Zipper::make('test.zip')->extractTo('public', array('vendor'), Zipper::WHITELIST);
-Which will extract the `test.zip` into the `public` folder but **only** the folder `vendor` inside the zip will be extracted.
+Which will extract the `test.zip` into the `public` folder but **only** files/folders starting with `vendor` prefix inside the zip will be extracted.
 
 or black listed
 
 >**Zipper::BLACKLIST**
 >
 	Zipper::make('test.zip')->extractTo('public', array('vendor'), Zipper::BLACKLIST);
-Which will extract the `test.zip` into the `public` folder except the folder `vendor` inside the zip will not be extracted.
+Which will extract the `test.zip` into the `public` folder except files/folders starting with `vendor` prefix inside the zip will not be extracted.
 
+>**Zipper::EXACT_MATCH**
+>
+	Zipper::make('test.zip')->folder('vendor')->extractTo('public', array('composer', 'bin/phpunit'), Zipper::WHITELIST | Zipper::EXACT_MATCH);
+Which will extract the `test.zip` into the `public` folder but **only** files/folders **exact matching names**. So this will:
+ * extract file or folder named `composer` in folder named `vendor` inside zip to `public` resulting `public/composer`
+ * extract file or folder named `bin/phpunit` in `vendor/bin/phpunit` folder inside zip to `public` resulting `public/bin/phpunit`
+
+> **NB: extracting files/folder from zip without setting Zipper::EXACT_MATCH 
+> would whitelist/blacklist both files and folder if only `test.bat` is given as whitelist/blacklist argument when zip has similar structure
+```
+test.zip
+ |- test.bat
+ |- test.bat.~
+ |- test.bat/
+    |- fileInSubFolder.log
+```
 
 
 ##Development

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ Specify a folder to 'add files to' or 'remove files from' from the zip, example
 	Zipper::make('test.zip')->folder('test')->remove('composer.json');
 
 
+##listFiles($regexFilter = null)
+
+Lists all files within archive (if no filter pattern is provided). Use `$regexFilter` parameter to filter files. See [Pattern Syntax](http://php.net/manual/en/reference.pcre.pattern.syntax.php) for regular expression syntax 
+
+> NB: `listFiles` ignores folder set with `folder` function
+
+
+Example: Return all files/folders ending with '.log' pattern (case insensitive). This will return matches in sub folders and their sub folders also
+```php
+$files = Zipper::make('test.zip')->listFiles('/\.log$/i'); 
+```
+
+
 ##home()
 
 Resets the folder pointer.

--- a/tests/Repositories/ZipRepositoryTest.php
+++ b/tests/Repositories/ZipRepositoryTest.php
@@ -36,7 +36,7 @@ class ZipRepositoryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @expectedException Exception
-     * @expectedExceptionMessage Error: Failed to open idonotexist.zip! Error: ZipArchive::ER_OPEN - Can't open file.
+     * @expectedExceptionMessage Error: Failed to open idonotexist.zip! Error: ZipArchive::ER_
      */
     public function testOpenNonExistentZipThrowsException()
     {

--- a/tests/ZipperTest.php
+++ b/tests/ZipperTest.php
@@ -19,12 +19,17 @@ class ZipperTest extends PHPUnit_Framework_TestCase
      */
     public $file;
 
-    public function __construct()
+    protected function setUp()
     {
         $this->archive = new \Chumper\Zipper\Zipper(
             $this->file = Mockery::mock(new Filesystem)
         );
         $this->archive->make('foo', new ArrayArchive('foo', true));
+    }
+
+    protected function tearDown()
+    {
+        Mockery::close();
     }
 
     public function testMake()
@@ -33,56 +38,65 @@ class ZipperTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $this->archive->getFilePath());
     }
 
-    public function testExtractTo()
-    {
-
-    }
-
     public function testAddAndGet()
     {
         $this->file->shouldReceive('isFile')->with('foo.bar')
-            ->times(3)->andReturn(true);
+            ->times(1)->andReturn(true);
         $this->file->shouldReceive('isFile')->with('foo')
-            ->times(3)->andReturn(true);
+            ->times(1)->andReturn(true);
 
-        /**Array**/
-        $this->file->shouldReceive('isFile')->with('/path/to/fooDir')
-            ->once()->andReturn(false);
-
-        $this->file->shouldReceive('files')->with('/path/to/fooDir')
-            ->once()->andReturn(array('foo.bar', 'bar.foo'));
-        $this->file->shouldReceive('directories')->with('/path/to/fooDir')
-            ->once()->andReturn(array('fooSubdir'));
-
-        $this->file->shouldReceive('files')->with('/path/to/fooDir/fooSubdir')
-            ->once()->andReturn(array('foo.bar'));
-        $this->file->shouldReceive('directories')->with('/path/to/fooDir/fooSubdir')
-            ->once()->andReturn(array());
-
-        //test1
         $this->archive->add('foo.bar');
         $this->archive->add('foo');
 
         $this->assertEquals('foo', $this->archive->getFileContent('foo'));
         $this->assertEquals('foo.bar', $this->archive->getFileContent('foo.bar'));
+    }
 
-        //test2
+    public function testAddAndGetWithArray()
+    {
+        $this->file->shouldReceive('isFile')->with('foo.bar')
+            ->times(1)->andReturn(true);
+        $this->file->shouldReceive('isFile')->with('foo')
+            ->times(1)->andReturn(true);
+
+        /**Array**/
         $this->archive->add(array(
             'foo.bar',
             'foo'
         ));
+
         $this->assertEquals('foo', $this->archive->getFileContent('foo'));
         $this->assertEquals('foo.bar', $this->archive->getFileContent('foo.bar'));
+    }
 
+    public function testAddAndGetWithSubFolder()
+    {
         /**
-         * test3:
          * Add the local folder /path/to/fooDir as folder fooDir to the repository
          * and make sure the folder structure within the repository is there.
          */
-        $this->archive->folder('fooDir')->add('/path/to/fooDir');
-        $this->assertEquals('fooDir/foo.bar', $this->archive->getFileContent('fooDir/foo.bar'));
-        $this->assertEquals('fooDir/bar.foo', $this->archive->getFileContent('fooDir/bar.foo'));
-        $this->assertEquals('fooDir/fooSubdir/foo.bar', $this->archive->getFileContent('fooDir/fooSubdir/foo.bar'));
+        $this->file->shouldReceive('isFile')->with('/path/to/fooDir')
+            ->once()->andReturn(false);
+
+
+        $this->file->shouldReceive('files')->with('/path/to/fooDir')
+            ->once()->andReturn(array('fileInFooDir.bar', 'fileInFooDir.foo'));
+
+        $this->file->shouldReceive('directories')->with('/path/to/fooDir')
+            ->once()->andReturn(array('fooSubdir'));
+
+
+        $this->file->shouldReceive('files')->with('/path/to/fooDir/fooSubdir')
+            ->once()->andReturn(array('fileInFooDir.bar'));
+        $this->file->shouldReceive('directories')->with('/path/to/fooDir/fooSubdir')
+            ->once()->andReturn(array());
+
+        $this->archive->folder('fooDir')
+            ->add('/path/to/fooDir');
+
+        $this->assertEquals('fooDir/fileInFooDir.bar', $this->archive->getFileContent('fooDir/fileInFooDir.bar'));
+        $this->assertEquals('fooDir/fileInFooDir.foo', $this->archive->getFileContent('fooDir/fileInFooDir.foo'));
+        $this->assertEquals('fooDir/fooSubdir/fileInFooDir.bar', $this->archive->getFileContent('fooDir/fooSubdir/fileInFooDir.bar'));
 
     }
 
@@ -127,68 +141,147 @@ class ZipperTest extends PHPUnit_Framework_TestCase
 
     public function testExtractWhiteList()
     {
-      $this->file
-        ->shouldReceive('isFile')
-        ->with('foo')
-        ->andReturn(true)
-      ;
+        $this->file
+            ->shouldReceive('isFile')
+            ->with('foo')
+            ->andReturn(true);
 
-      $this->archive
-        ->add('foo')
-      ;
+        $this->file
+            ->shouldReceive('isFile')
+            ->with('foo.log')
+            ->andReturn(true);
 
-      $this->file
-        ->shouldReceive('put')
-        ->with(realpath(NULL) . '/foo', 'foo')
-      ;
+        $this->archive
+            ->add('foo')
+            ->add('foo.log');
 
-      $this->archive
-        ->extractTo(getcwd(), array('foo'), Zipper::WHITELIST)
-      ;
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/foo', 'foo');
 
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/foo.log', 'foo.log');
 
-      $this->file
-        ->shouldReceive('isFile')
-        ->with('foo')
-        ->andReturn(true)
-      ;
-
-      $this->archive
-        ->folder('foo/bar')
-        ->add('foo')
-      ;
-
-      $this->file
-        ->shouldReceive('put')
-        ->with(realpath(NULL) . '/foo', 'foo/bar/foo')
-      ;
-
-      $this->archive
-        ->extractTo(getcwd(), array('foo'), Zipper::WHITELIST)
-      ;
-
+        $this->archive
+            ->extractTo(getcwd(), array('foo'), Zipper::WHITELIST);
     }
 
-    public function testExtractBlackList()
+    public function testExtractWhiteListFromSubDirectory()
+    {
+        $this->file->shouldReceive('isFile')->andReturn(true);
+
+        $this->archive
+            ->folder('foo/bar')
+            ->add('baz')
+            ->add('baz.log');
+
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/baz', 'foo/bar/baz');
+
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/baz.log', 'foo/bar/baz.log');
+
+        $this->archive
+            ->extractTo(getcwd(), array('baz'), Zipper::WHITELIST);
+    }
+
+    public function testExtractWhiteListWithExactMatching()
+    {
+        $this->file->shouldReceive('isFile')->andReturn(true);
+
+        $this->archive
+            ->folder('foo/bar')
+            ->add('baz')
+            ->add('baz.log');
+
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/baz', 'foo/bar/baz');
+
+        $this->archive
+            ->extractTo(getcwd(), array('baz'), Zipper::WHITELIST | Zipper::EXACT_MATCH);
+    }
+
+    public function testExtractWhiteListWithExactMatchingFromSubDirectory()
+    {
+        $this->file->shouldReceive('isFile')->andReturn(true);
+        $this->file->shouldReceive('makeDirectory')->andReturn(true);
+
+        $this->archive->folder('foo/bar/subDirectory')
+            ->add('bazInSubDirectory')
+            ->add('bazInSubDirectory.log');
+
+        $this->archive->folder('foo/bar')
+            ->add('baz')
+            ->add('baz.log');
+
+        $this->file
+            ->shouldReceive('put')
+            ->with(realpath(NULL) . '/subDirectory/bazInSubDirectory', 'foo/bar/subDirectory/bazInSubDirectory');
+
+        $this->archive
+            ->extractTo(getcwd(), array('subDirectory/bazInSubDirectory'), Zipper::WHITELIST | Zipper::EXACT_MATCH);
+    }
+
+    public function testExtractToIgnoresBlackListFile()
     {
         $this->file->shouldReceive('isFile')->with('foo')
             ->andReturn(true);
-
-        $this->archive->add('foo');
-
-        $this->file->shouldReceive('put')->with(realpath(NULL) . '/foo', 'foo');
-
-        $this->archive->extractTo(getcwd(), array(), Zipper::BLACKLIST);
-
-        //----
-        $this->file->shouldReceive('isFile')->with('foo')
+        $this->file->shouldReceive('isFile')->with('bar')
             ->andReturn(true);
 
-        $this->archive->folder('foo/bar')->add('foo');
+        $this->archive->add('foo')
+            ->add('bar');
 
-        $this->file->shouldReceive('put')->with(realpath(NULL) . '/foo', 'foo/bar/foo');
+        $this->file->shouldReceive('put')->with(realpath(NULL) . DIRECTORY_SEPARATOR . 'foo', 'foo');
+        $this->file->shouldNotReceive('put')->with(realpath(NULL) . DIRECTORY_SEPARATOR . 'bar', 'bar');
 
-        $this->archive->extractTo(getcwd(), array('foo'), Zipper::BLACKLIST);
+        $this->archive->extractTo(getcwd(), array('bar'), Zipper::BLACKLIST);
+    }
+
+    public function testExtractBlackListFromSubDirectory()
+    {
+        $currentDir = getcwd();
+
+        $this->file->shouldReceive('isFile')->andReturn(true);
+        $this->file->shouldReceive('makeDirectory')->andReturn(true);
+
+        $this->archive->add('rootLevelFile');
+
+        $this->archive->folder('foo/bar/sub')
+            ->add('fileInSubSubDir');
+
+        $this->archive->folder('foo/bar')
+            ->add('fileInSubDir')
+            ->add('fileBlackListedInSubDir');
+
+        $this->file->shouldReceive('put')->with($currentDir . DIRECTORY_SEPARATOR . 'fileInSubDir', 'foo/bar/fileInSubDir');
+        $this->file->shouldReceive('put')->with($currentDir . DIRECTORY_SEPARATOR . 'sub/fileInSubSubDir', 'foo/bar/sub/fileInSubSubDir');
+
+        $this->file->shouldNotReceive('put')->with($currentDir . DIRECTORY_SEPARATOR . 'fileBlackListedInSubDir', 'fileBlackListedInSubDir');
+        $this->file->shouldNotReceive('put')->with($currentDir . DIRECTORY_SEPARATOR . 'rootLevelFile', 'rootLevelFile');
+
+        $this->archive->extractTo($currentDir, array('fileBlackListedInSubDir'), Zipper::BLACKLIST);
+    }
+
+    public function testExtractBlackListFromSubDirectoryWithExactMatching()
+    {
+        $this->file->shouldReceive('isFile')->with('baz')
+            ->andReturn(true);
+
+        $this->file->shouldReceive('isFile')->with('baz.log')
+            ->andReturn(true);
+
+        $this->archive->folder('foo/bar')
+            ->add('baz')
+            ->add('baz.log');
+
+        $this->file->shouldReceive('put')->with(realpath(NULL) . DIRECTORY_SEPARATOR . 'baz.log', 'foo/bar/baz.log');
+
+        $this->archive->extractTo(getcwd(), array('baz'), Zipper::BLACKLIST | Zipper::EXACT_MATCH);
     }
 
     public function testNavigationFolderAndHome()


### PR DESCRIPTION
This PR contains following changes/additions:

* added `extractMatchingRegex($extractToPath, $regex)` method
* changed `extractTo` to supports exact file name matching,
* changed `listFiles` accepts regexp parameter to filter files
* if makedir fails to create folder this will not be silently ignored and will throw exception now
* refactored all extract internal logic. this blacklist/whitelist code had a lot duplicate code blocks
* update readme
* updated travisCI config

Should I squash all changes to one commit?

If you do not like some parts do let me know. I'll fix those as you see fit.