### PR TITLE
added setPermissionMode to create files/folders with specific mode ala 0777

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Which will extract the `test.zip` into the `public` folder but **only** files/fo
 test.zip
  |- test.bat
  |- test.bat.~
- |- test.bat/
+ |- test.bat.dir/
     |- fileInSubFolder.log
 ```
 
@@ -186,6 +186,20 @@ Zipper::make('test.zip')->folder->('src')->extractMatchingRegex($path, '/\.php$/
 Example: extract all files **except** those ending with `test.php` from `src` folder and its sub folders.
 ```php
 Zipper::make('test.zip')->folder->('src')->extractMatchingRegex($path, '/^(?!.*test\.php).*$/i'); 
+```
+
+##setPermissionMode($mode)
+
+Set permission mode used to create files and folders. For details read [mode parameter info at chmod manual](http://php.net/manual/en/function.chmod.php)
+
+> default mode to create files/folder is 0755
+
+Example: extract files with 0755 mode
+```php
+Zipper::make('test.zip')
+    ->setPermissionMode(0755)
+    ->folder->('vendor')
+    ->extractTo('public');
 ```
 
 #Development

--- a/src/Chumper/Zipper/Repositories/RepositoryInterface.php
+++ b/src/Chumper/Zipper/Repositories/RepositoryInterface.php
@@ -33,6 +33,15 @@ interface RepositoryInterface
     public function addFile($pathToFile, $pathInArchive);
 
     /**
+     * Add a file to the opened Archive using its contents
+     *
+     * @param $name
+     * @param $content
+     * @return void
+     */
+    public function addFromString($name, $content);
+
+    /**
      * Add an empty directory
      *
      * @param $dirName

--- a/tests/ArrayArchive.php
+++ b/tests/ArrayArchive.php
@@ -30,6 +30,18 @@ class ArrayArchive implements RepositoryInterface
     }
 
     /**
+     * Add a file to the opened Archive using its contents
+     *
+     * @param $name
+     * @param $content
+     * @return void
+     */
+    public function addFromString($name, $content)
+    {
+        $this->entries[$name] = $name;
+    }
+
+    /**
      * Remove a file permanently from the Archive
      *
      * @param $pathInArchive


### PR DESCRIPTION
* added `setPermissionMode` to create files/folders with specific mode ala 0777
* fixed some of the warnings that Idea/phpstorm inspectors gave
* fixed problem with path when extracting files - strpos'sing path to find directory part is not that clever as directory separator is different on windows vs linux
* `extractTo` now honors folder set with `folder()`