### PR TITLE
 fixed problem with path when extracting files - strpos'sing path to find directory part is not that clever as directory separator is different on windows vs linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ This will go into the folder `test` in the zip file and extract the content of t
 
 This command is really nice to get just a part of the zip file, you can also pass a 2nd & 3rd param to specify a single or an array of files that will be
 
+> NB: Php ZipArchive uses internally '/' as directory separator for files/folders in zip. So Windows users should not set 
+> whitelist/blacklist patterns with '\' as it will not match anything
+
 white listed
 
 >**Zipper::WHITELIST**
@@ -170,7 +173,7 @@ Which will extract the `test.zip` into the `public` folder but **only** files/fo
 test.zip
  |- test.bat
  |- test.bat.~
- |- test.bat/
+ |- test.bat.dir/
     |- fileInSubFolder.log
 ```
 

--- a/src/Chumper/Zipper/Repositories/RepositoryInterface.php
+++ b/src/Chumper/Zipper/Repositories/RepositoryInterface.php
@@ -33,6 +33,15 @@ interface RepositoryInterface
     public function addFile($pathToFile, $pathInArchive);
 
     /**
+     * Add a file to the opened Archive using its contents
+     *
+     * @param $name
+     * @param $content
+     * @return void
+     */
+    public function addFromString($name, $content);
+
+    /**
      * Add an empty directory
      *
      * @param $dirName

--- a/tests/ArrayArchive.php
+++ b/tests/ArrayArchive.php
@@ -30,6 +30,18 @@ class ArrayArchive implements RepositoryInterface
     }
 
     /**
+     * Add a file to the opened Archive using its contents
+     *
+     * @param $name
+     * @param $content
+     * @return void
+     */
+    public function addFromString($name, $content)
+    {
+        $this->entries[$name] = $name;
+    }
+
+    /**
      * Remove a file permanently from the Archive
      *
      * @param $pathInArchive
@@ -115,7 +127,7 @@ class ArrayArchive implements RepositoryInterface
      * @return void
      */
     public function addEmptyDir($dirName){
-      # CODE...
+        # CODE...
     }
 
     /**
@@ -126,6 +138,6 @@ class ArrayArchive implements RepositoryInterface
      */
     public function usePassword($password)
     {
-      # CODE...
+        # CODE...
     }
 }

--- a/tests/ZipperTest.php
+++ b/tests/ZipperTest.php
@@ -254,6 +254,7 @@ class ZipperTest extends PHPUnit_Framework_TestCase
     public function testExtractWhiteListWithExactMatchingFromSubDirectory()
     {
         $this->file->shouldReceive('isFile')->andReturn(true);
+        $this->file->shouldReceive('exists')->andReturn(false);
         $this->file->shouldReceive('makeDirectory')->andReturn(true);
 
         $this->archive->folder('foo/bar/subDirectory')
@@ -264,12 +265,15 @@ class ZipperTest extends PHPUnit_Framework_TestCase
             ->add('baz')
             ->add('baz.log');
 
-        $this->file
-            ->shouldReceive('put')
-            ->with(realpath(NULL) . DIRECTORY_SEPARATOR . 'subDirectory/bazInSubDirectory', 'foo/bar/subDirectory/bazInSubDirectory');
+        $subDirectoryPath = realpath(NULL) . DIRECTORY_SEPARATOR . 'subDirectory';
+        $subDirectoryFilePath = $subDirectoryPath . '/bazInSubDirectory';
+        $this->file->shouldReceive('put')
+            ->with($subDirectoryFilePath, 'foo/bar/subDirectory/bazInSubDirectory');
 
         $this->archive
             ->extractTo(getcwd(), array('subDirectory/bazInSubDirectory'), Zipper::WHITELIST | Zipper::EXACT_MATCH);
+
+        $this->file->shouldHaveReceived('makeDirectory')->with($subDirectoryPath, 0755, true, true);
     }
 
     public function testExtractToIgnoresBlackListFile()


### PR DESCRIPTION
Most important
* fixed problem with path when extracting files - strpos'sing path to find directory part is not that clever as directory separator is different on windows vs linux

and extras
* fixed some of the warnings that Idea/phpstorm inspectors gave
* extractTo now honors folder set with folder()