### PR TITLE
Custom filenames in .zip

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -246,8 +246,12 @@ class Zipper
     public function add($pathToAdd, $fileName = null)
     {
         if (is_array($pathToAdd)) {
-            foreach ($pathToAdd as $dir) {
-                $this->add($dir);
+            foreach ($pathToAdd as $key=>$dir) {
+                if (!is_int($key)) {
+                    $this->add($dir, $key); }
+                else {
+                    $this->add($dir);
+                }
             }
         } elseif ($this->file->isFile($pathToAdd)) {
             if ($fileName) {

--- a/tests/ZipperTest.php
+++ b/tests/ZipperTest.php
@@ -84,6 +84,23 @@ class ZipperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('foo', $this->archive->getFileContent('foo'));
         $this->assertSame('foo.bar', $this->archive->getFileContent('foo.bar'));
     }
+    
+    public function testAddAndGetWithCustomFilenameArray()
+    {
+        $this->file->shouldReceive('isFile')->with('foo.bar')
+            ->times(1)->andReturn(true);
+        $this->file->shouldReceive('isFile')->with('foo')
+            ->times(1)->andReturn(true);
+
+        /**Array**/
+        $this->archive->add([
+            'custom.bar' => 'foo.bar',
+            'custom' => 'foo',
+        ]);
+
+        $this->assertSame('custom', $this->archive->getFileContent('custom'));
+        $this->assertSame('custom.bar', $this->archive->getFileContent('custom.bar'));
+    }
 
     public function testAddAndGetWithSubFolder()
     {


### PR DESCRIPTION

Ability to set custom names for files in archive:

```
$zipper->add(
   array('image.jpg' => '/path/to/file.jpg')
)
```

