### PR TITLE
Prevent the attempted function call on what is sometimes a string

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -63,7 +63,7 @@ class Zipper
      */
     public function __destruct()
     {
-        if (null !== $this->repository) {
+        if (is_object($this->repository)) {
             $this->repository->close();
         }
     }


### PR DESCRIPTION
As it happens, I didn't have zip support, but I couldn't find this out due to this check. If you must have a variable as a mixed type, please check it appropriately in vital functions (`__destruct`, `__toString`, etc.)