### PR TITLE
Fixed for better exception throwing for issue #117

### DIFF
--- a/src/Chumper/Zipper/Repositories/ZipRepository.php
+++ b/src/Chumper/Zipper/Repositories/ZipRepository.php
@@ -116,6 +116,7 @@ class ZipRepository implements RepositoryInterface
             }
             call_user_func_array($callback, [
                 'file' => $this->archive->getNameIndex($i),
+                'stats' => $this->archive->statIndex($i)
             ]);
         }
     }


### PR DESCRIPTION
$this should not be assigned with any information as long it is not clear that the corresponding repositories can be loaded. Otherwise there won't be throwing the right exception. Now for instance the corrector exception will be

> Error: Your PHP version is not compiled with zip support

Instead of

> Call to a member function close() on string