### PR TITLE
Change location of unused statement outside block

### DIFF
--- a/src/Chumper/Zipper/Zipper.php
+++ b/src/Chumper/Zipper/Zipper.php
@@ -561,9 +561,8 @@ class Zipper
      */
     private function addFile($pathToAdd, $fileName = null)
     {
-        $info = pathinfo($pathToAdd);
-
         if (!$fileName) {
+            $info = pathinfo($pathToAdd);
             $fileName = isset($info['extension']) ?
                 $info['filename'].'.'.$info['extension'] :
                 $info['filename'];


### PR DESCRIPTION
The statement `$info = pathinfo($pathToAdd);` not used outside **if block**, we can put it inside the block